### PR TITLE
Added support for using ruby capabilities manually defined as type 'command' because the auto-detected type 'ruby' is not an option for remote agents.

### DIFF
--- a/src/main/java/com/alienfast/bamboozled/ruby/rt/RubyCapabilityDefaultsHelper.java
+++ b/src/main/java/com/alienfast/bamboozled/ruby/rt/RubyCapabilityDefaultsHelper.java
@@ -93,11 +93,15 @@ public class RubyCapabilityDefaultsHelper implements CapabilityDefaultsHelper {
                     final RubyLabel rubyLabel = new RubyLabel(
                             rubyRuntimeLocatorService.getRuntimeManagerName(),
                             rubyRuntime.getRubyRuntimeName() );
-                    final String capabilityKey = rubyLabel.toCapabilityKey();
-                    log.info( "Adding " + capabilityKey );
-                    final Capability capability = new CapabilityImpl( capabilityKey, rubyRuntime.getRubyExecutablePath() );
-                    log.info( "Added {}", capability );
-                    capabilitySet.addCapability( capability );
+
+                    // Add capabilities for either 'command' or 'ruby' in order to support remote agents.
+                    for (RubyLabel.CapabilityType capabilityType : RubyLabel.CapabilityType.values()) {
+                        String capabilityKey = rubyLabel.toCapabilityKey(capabilityType);
+                        log.info( "Adding " + capabilityKey );
+                        final Capability capability = new CapabilityImpl( capabilityKey, rubyRuntime.getRubyExecutablePath() );
+                        log.info( "Added {}", capability );
+                        capabilitySet.addCapability( capability );
+                    }
                 }
             }
         }

--- a/src/main/java/com/alienfast/bamboozled/ruby/rt/RubyLabel.java
+++ b/src/main/java/com/alienfast/bamboozled/ruby/rt/RubyLabel.java
@@ -11,10 +11,20 @@ public class RubyLabel {
 
     // This is to support existing deployments where the registered runtimes lack a runtime manager prefix.
     static final String DEFAULT_RUNTIME_MANAGER = "RVM";
-    private static final String RUBY_CAPABILITY_PREFIX = CapabilityDefaultsHelper.CAPABILITY_BUILDER_PREFIX + ".ruby";
 
     private String rubyRuntimeManager;
     private String rubyRuntime;
+
+    public enum CapabilityType {
+        RUBY(CapabilityDefaultsHelper.CAPABILITY_BUILDER_PREFIX + ".ruby"),
+        COMMAND(CapabilityDefaultsHelper.CAPABILITY_BUILDER_PREFIX + ".command");
+
+        private String value;
+        private CapabilityType(String value) {
+
+            this.value = value;
+        }
+    }
 
     public RubyLabel(String rubyRuntimeManager, String rubyRuntime) {
 
@@ -54,9 +64,9 @@ public class RubyLabel {
         }
     }
 
-    public String toCapabilityKey() {
+    public String toCapabilityKey( CapabilityType type ) {
 
-        return String.format( "%s.%s", RUBY_CAPABILITY_PREFIX, this );
+        return String.format( "%s.%s", type.value, this );
     }
 
     @Override

--- a/src/main/java/com/alienfast/bamboozled/ruby/tasks/AbstractRubyTask.java
+++ b/src/main/java/com/alienfast/bamboozled/ruby/tasks/AbstractRubyTask.java
@@ -158,9 +158,15 @@ public abstract class AbstractRubyTask implements CommonTaskType {
 
     protected String getRubyExecutablePath( final RubyLabel rubyRuntimeLabel ) {
 
-        final Capability capability = getCapabilityContext().getCapabilitySet().getCapability( rubyRuntimeLabel.toCapabilityKey() );
-        Preconditions.checkNotNull( capability, "Capability  for ruby " + rubyRuntimeLabel.toCapabilityKey()
-                + ".  Please be sure to \"Detect server capabilities\" in the Administration console, and the path is valid." );
+        String capabilityKey = rubyRuntimeLabel.toCapabilityKey(RubyLabel.CapabilityType.RUBY);
+        Capability capability = this.getCapabilityContext().getCapabilitySet().getCapability( capabilityKey );
+
+        if (null == capability) {
+            capabilityKey = rubyRuntimeLabel.toCapabilityKey(RubyLabel.CapabilityType.COMMAND);
+            capability = this.getCapabilityContext().getCapabilitySet().getCapability( capabilityKey );
+        }
+
+        Preconditions.checkNotNull( capability, "Capability : " + capabilityKey );
         final String rubyRuntimeExecutable = capability.getValue();
         Preconditions.checkNotNull( rubyRuntimeExecutable, "rubyRuntimeExecutable" );
         return rubyRuntimeExecutable;

--- a/src/test/java/com/alienfast/bamboozled/ruby/tasks/AbstractRubyTest.java
+++ b/src/test/java/com/alienfast/bamboozled/ruby/tasks/AbstractRubyTest.java
@@ -45,8 +45,7 @@ public abstract class AbstractRubyTest {
     public void setUp() throws Exception {
 
         when( getCapability().getValue() ).thenReturn( getRubyRuntime().getRubyExecutablePath() );
-        when( getCapabilitySet().getCapability( getRubyLabel().toCapabilityKey() ) ).thenReturn( getCapability() );
-        //        when( this.capabilityContext.getCapabilitySet() ).thenReturn( this.capabilitySet );
+        when( getCapabilitySet().getCapability( getRubyLabel().toCapabilityKey(RubyLabel.CapabilityType.RUBY) ) ).thenReturn( getCapability() );
 
         // setup xvfb-run
         when( getXvfbRunCapability().getValue() ).thenReturn( "/usr/bin/xvfb-run" );

--- a/src/test/java/com/alienfast/bamboozled/ruby/tasks/bundler/cli/BundlerCliTaskTest.java
+++ b/src/test/java/com/alienfast/bamboozled/ruby/tasks/bundler/cli/BundlerCliTaskTest.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.alienfast.bamboozled.ruby.fixtures.RvmFixtures;
+import com.alienfast.bamboozled.ruby.rt.RubyLabel;
 import com.alienfast.bamboozled.ruby.rt.RuntimeLocatorException;
 import com.alienfast.bamboozled.ruby.tasks.AbstractBundleExecCommandBuilder;
 import com.alienfast.bamboozled.ruby.tasks.AbstractTaskTest;
@@ -45,7 +46,7 @@ public class BundlerCliTaskTest extends AbstractTaskTest {
         this.bundlerCliTask.setCapabilityContext( getCapabilityContext() );
 
         when( getCapability().getValue() ).thenReturn( getRubyRuntime().getRubyExecutablePath() );
-        when( getCapabilitySet().getCapability( getRubyLabel().toCapabilityKey() ) ).thenReturn( getCapability() );
+        when( getCapabilitySet().getCapability( getRubyLabel().toCapabilityKey(RubyLabel.CapabilityType.RUBY) ) ).thenReturn( getCapability() );
         when( getCapabilityContext().getCapabilitySet() ).thenReturn( getCapabilitySet() );
 
         setupBuildContext( this.bundlerCliTask );

--- a/src/test/java/com/alienfast/bamboozled/ruby/tasks/bundler/install/BundlerInstallTaskTest.java
+++ b/src/test/java/com/alienfast/bamboozled/ruby/tasks/bundler/install/BundlerInstallTaskTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.alienfast.bamboozled.ruby.fixtures.RvmFixtures;
+import com.alienfast.bamboozled.ruby.rt.RubyLabel;
 import com.alienfast.bamboozled.ruby.rt.RuntimeLocatorException;
 import com.alienfast.bamboozled.ruby.tasks.AbstractTaskTest;
 import com.google.common.collect.Maps;
@@ -37,7 +38,7 @@ public class BundlerInstallTaskTest extends AbstractTaskTest {
         this.bundlerInstallTask.setCapabilityContext( getCapabilityContext() );
 
         when( getCapability().getValue() ).thenReturn( getRubyRuntime().getRubyExecutablePath() );
-        when( getCapabilitySet().getCapability( getRubyLabel().toCapabilityKey() ) ).thenReturn( getCapability() );
+        when( getCapabilitySet().getCapability( getRubyLabel().toCapabilityKey(RubyLabel.CapabilityType.COMMAND) ) ).thenReturn( getCapability() );
         when( getCapabilityContext().getCapabilitySet() ).thenReturn( getCapabilitySet() );
 
         getConfigurationMap().put( "ruby", getRubyRuntime().getRubyRuntimeName() );

--- a/src/test/java/com/alienfast/bamboozled/ruby/tasks/capistrano/CapistranoTaskTest.java
+++ b/src/test/java/com/alienfast/bamboozled/ruby/tasks/capistrano/CapistranoTaskTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.alienfast.bamboozled.ruby.fixtures.RvmFixtures;
+import com.alienfast.bamboozled.ruby.rt.RubyLabel;
 import com.alienfast.bamboozled.ruby.rt.RuntimeLocatorException;
 import com.alienfast.bamboozled.ruby.tasks.AbstractBundleExecCommandBuilder;
 import com.alienfast.bamboozled.ruby.tasks.AbstractTaskTest;
@@ -40,7 +41,7 @@ public class CapistranoTaskTest extends AbstractTaskTest {
         this.capistranoTask.setCapabilityContext( getCapabilityContext() );
 
         when( getCapability().getValue() ).thenReturn( getRubyRuntime().getRubyExecutablePath() );
-        when( getCapabilitySet().getCapability( getRubyLabel().toCapabilityKey() ) ).thenReturn( getCapability() );
+        when( getCapabilitySet().getCapability( getRubyLabel().toCapabilityKey(RubyLabel.CapabilityType.RUBY) ) ).thenReturn( getCapability() );
         when( getCapabilityContext().getCapabilitySet() ).thenReturn( getCapabilitySet() );
 
         setupBuildContext( this.capistranoTask );


### PR DESCRIPTION
I believe this PR will address this issue: https://github.com/alienfast/bamboozled-ruby-plugin/issues/5