### PR TITLE
Adding /usr/share/rvm to KNOWN_RVM_HOME_PATHS

### DIFF
--- a/src/main/java/com/alienfast/bamboozled/ruby/rt/rvm/RvmRubyRuntimeLocatorService.java
+++ b/src/main/java/com/alienfast/bamboozled/ruby/rt/rvm/RvmRubyRuntimeLocatorService.java
@@ -21,7 +21,7 @@ public class RvmRubyRuntimeLocatorService implements RubyRuntimeLocatorService {
 
     public static final String MANAGER_LABEL = "RVM";
 
-    static final String[] KNOWN_RVM_HOME_PATHS = new String[] { "/usr/local/rvm", "/opt/local/rvm" };
+    static final String[] KNOWN_RVM_HOME_PATHS = new String[] { "/usr/local/rvm", "/opt/local/rvm","/usr/share/rvm" };
 
     private final FileSystemHelper fileSystemHelper;
 


### PR DESCRIPTION
RvmRubyRuntimeLocatorService won't find RVM when I have it installed in a multi-user location. 